### PR TITLE
test(core): add e2e test for new args feature

### DIFF
--- a/e2e/core-e2e/tests/nx-dotnet.spec.ts
+++ b/e2e/core-e2e/tests/nx-dotnet.spec.ts
@@ -442,7 +442,7 @@ public class UnitTest1
     [Fact]
     public void Test1()
     {
-      Assert.Equal(1, 2)
+      Assert.Equal(1, 2);
     }
 }`,
       );

--- a/e2e/core-e2e/tests/nx-dotnet.spec.ts
+++ b/e2e/core-e2e/tests/nx-dotnet.spec.ts
@@ -117,6 +117,18 @@ describe('nx-dotnet e2e', () => {
       ).toThrow();
     });
 
+    it('should generate an app without launchSettings.json', async () => {
+      const app = uniq('app');
+      await runNxCommandAsync(
+        `generate @nx-dotnet/core:app ${app} --language="C#" --template="webapi" --args="--exclude-launch-settings=true"`,
+      );
+
+      expect(() => checkFilesExist(`apps/${app}`)).not.toThrow();
+      expect(() =>
+        checkFilesExist(`apps/${app}/Properties/launchSettings.json`),
+      ).toThrow();
+    });
+
     it('should build and test an app', async () => {
       const app = uniq('app');
       const testProj = `${app}-test`;


### PR DESCRIPTION
I am not sure if this e2e test implementation will be approved by the nx-dotnet team but it appears to work fine when I ran it locally.